### PR TITLE
Handle no SRPMs properly

### DIFF
--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ def main():
     if args.rm:
         docker_args += ["--rm=true"]
     # Copy all the RPMs to the mount directory
-    if args.srpm != []:
+    if args.srpm:
         srpm_mount_dir = make_mount_dir()
         copy_srpms(srpm_mount_dir, args.srpm)
         docker_args += ["-v", "%s:/mnt/docker-SRPMS" % srpm_mount_dir]


### PR DESCRIPTION
If no SRPMs are supplied, then args.srpm is None, not [].
