### PR TITLE
Add -p option to run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,18 @@ Find an SRPM you'd like to build, either one you've built yourself, or
 one from the
 [build system](http://coltrane.uk.xensource.com/usr/groups/build/trunk/latest/binary-packages/RPMS/domain0/SRPMS/)
 
-Start a container with a XenServer branch name and at least one SRPM like so:
+Start a container with a XenServer branch name, zero or more package names, and
+zero or more SRPM paths like so:
 
 ```sh
-./run.py -b trunk-ring3 -s xenopsd-0.10.1-1+s0+0.10.1+10+gf2c98e0.el7.centos.src.rpm
+./run.py -b trunk-ring3 -p xapi -s xenopsd-0.10.1-1+s0+0.10.1+10+gf2c98e0.el7.centos.src.rpm
 ```
 
-The container will run yum-builddep against the SRPM, using the yum repository
-for the specified branch, and drop you into an interactive shell. You should
-then have all the dependencies to be able to build the component whose SRPM was
-specified above, e.g.
+The container will run yumdownloader to download the SRPM for each package
+specified with -p, run yum-builddep against these SRPMs as well as the SRPMs
+specified with -s, and drop you into an interactive shell.  You should then have
+all the dependencies to be able to build the components whose SRPM or package
+name was specified above, e.g.
 
 ```sh
 git clone git://github.com/xapi-project/xenopsd

--- a/run.py
+++ b/run.py
@@ -57,6 +57,9 @@ def main():
     parser.add_argument('-b', '--branch',
                         help='XenServer branch name (default trunk)',
                         default='trunk')
+    parser.add_argument('-p', '--package', action='append',
+                        help='Packages for which dependencies will '
+                        'be installed')
     parser.add_argument('-s', '--srpm', action='append',
                         help='SRPMs for which dependencies will be installed')
     parser.add_argument('-d', '--dir', action='append',
@@ -72,6 +75,10 @@ def main():
         ]
     if args.rm:
         docker_args += ["--rm=true"]
+    # Add package names to the environment
+    if args.package:
+        packages = ' '.join(args.package)
+        docker_args += ['-e', "PACKAGES=%s" % packages]
     # Copy all the RPMs to the mount directory
     if args.srpm:
         srpm_mount_dir = make_mount_dir()


### PR DESCRIPTION
This allows the user to specify one or more package names, for which the
SRPM will be downloaded inside the chroot. Each of these SRPMs will be
used to install dependencies, alongside any SRPMs specified with the -s
option.
