### PR TITLE
init-container.sh: Double default stack size limit

### DIFF
--- a/files/init-container.sh
+++ b/files/init-container.sh
@@ -36,4 +36,7 @@ do
     sudo yum-builddep -y $SRPM
 done
 
+# double the default stack size
+ulimit -s 16384
+
 /bin/sh --login


### PR DESCRIPTION
This is now enough to build the `xapi` package. Previous attempts failed with:

```
exception: Stack_overflow
```

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
