### PR TITLE
Clean the metadata for the xs repo before finishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,5 @@ RUN     usermod -G mock builder
 RUN     mkdir -p /usr/local/bin
 COPY    files/init-container.sh        /usr/local/bin/init-container.sh
 
+RUN	yum --enablerepo=xs clean metadata
+


### PR DESCRIPTION
This is necessary as we don't incrementally put new stuff
in the repo, but we rebuild it every time from scratch.

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
