### PR TITLE
Add gcc and gcc-g++ to the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ COPY    files/xs.repo.in /tmp/xs.repo.in
 
 # Build requirements
 RUN     yum install -y \
+            gcc \
+            gcc-c++ \
             git \
             make \
             mercurial \


### PR DESCRIPTION
This mirrors the setup in the mock config used by xenserver.

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
