### PR TITLE
Update URL to Citrix-internal Fedora repository

### DIFF
--- a/files/yum.conf.xs
+++ b/files/yum.conf.xs
@@ -26,7 +26,7 @@ reposdir=/etc/yum.repos.d.xs
 [epel]
 name = epel
 enabled = 1
-baseurl = https://repo.citrite.net/fedora/epel/7/x86_64/
+baseurl = https://repo.citrite.net/ctx-remote-yum-fedora/epel/7/x86_64/
 exclude = ocaml*
 gpgcheck = 0
 


### PR DESCRIPTION
The URL changed and the server no longer provides a redirect:

Old: repo.citrite.net/fedora
New: repo.citrite.net/ctx-remote-yum-fedora

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>