### PR TITLE
Dockerfile: Don't install aspcud and its dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,11 +51,5 @@ RUN     echo "builder:builder" | chpasswd
 RUN     echo "builder ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN     usermod -G mock builder
 
-# Let's have aspcud
-RUN     yum install -y \
-            http://download.opensuse.org/repositories/home:/ocaml/CentOS_7/x86_64/aspcud-1.9.0-2.2.x86_64.rpm \
-            http://download.opensuse.org/repositories/home:/ocaml/CentOS_7/x86_64/clasp-3.0.1-4.2.x86_64.rpm \
-            http://download.opensuse.org/repositories/home:/ocaml/CentOS_7/x86_64/gringo-4.3.0-10.2.x86_64.rpm
-
 RUN     mkdir -p /usr/local/bin
 COPY    files/init-container.sh        /usr/local/bin/init-container.sh


### PR DESCRIPTION
The aspcud package that we try to download in the Dockerfile has
recently disappeared, and as a result building the docker image fails.
It seems that aspcud is not necessary for our builds, so we can remove
it.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>